### PR TITLE
Update maven pom.xml to use JogAmp 2.3.2 released at 2015-10-10

### DIFF
--- a/modern-jogl-examples/pom.xml
+++ b/modern-jogl-examples/pom.xml
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.jogamp.gluegen</groupId>
             <artifactId>gluegen-rt-main</artifactId>
-            <version>2.0.2</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.jogamp.jogl</groupId>
             <artifactId>jogl-all-main</artifactId>
-            <version>2.0.2</version>
+            <version>2.3.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
mvn install
mvn exec:java